### PR TITLE
Update relationship-utils.updateHasManyThrough to fix mongodb ObjectID/ string id comparison

### DIFF
--- a/lib/utilities/relationship-utils.js
+++ b/lib/utilities/relationship-utils.js
@@ -156,7 +156,7 @@ function updateHasManyThrough (
 ) {
   return PivotModel.find({ where: { [leftFKName]: leftPKValue } })
     .then(models => {
-      const existingIds = models.map(model => model[rightFKName])
+      const existingIds = models.map(model => _(model[rightFKName]).toString())
       const idsToDelete = _.difference(existingIds, rightFKValues)
       return PivotModel.destroyAll({
         [leftFKName]: leftPKValue,


### PR DESCRIPTION
When updating (PATCHing) a model with existing relationships the `existingIds` check in [relationship-utils.updateHasManyThrough](https://github.com/digitalsadhu/loopback-component-jsonapi/blob/master/lib/utilities/relationship-utils.js#L159) was comparing the string id from the request vs the ObjectId from the `PivotModel.find`